### PR TITLE
chore: update node to 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker: 
-      - image: circleci/node:14
+      - image: circleci/node:18
     working_directory: ~/project
     steps:
       - checkout


### PR DESCRIPTION
Update Node.js version to 18 to resolve CI build failure.